### PR TITLE
Inconsistent line endings

### DIFF
--- a/DocGpt.Roslyn/DocGpt.Roslyn.csproj
+++ b/DocGpt.Roslyn/DocGpt.Roslyn.csproj
@@ -19,8 +19,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.12" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+		<PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.17" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/DocGpt.Roslyn/DocGptAnalyzer.cs
+++ b/DocGpt.Roslyn/DocGptAnalyzer.cs
@@ -1,11 +1,11 @@
 ﻿namespace DocGpt
 {
+    using System.Collections.Immutable;
+
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
-
-    using System.Collections.Immutable;
 
     using static Helpers;
 
@@ -27,7 +27,7 @@
         internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Info, isEnabledByDefault: true, description: Description);
 
         /// <inheritdoc />
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         /// <inheritdoc />
         public override void Initialize(AnalysisContext context)
@@ -41,14 +41,12 @@
             }
         }
 
-        private void AnalyzeNode(SyntaxNodeAnalysisContext context) => AnalyzeNode(context, false);
-
         /// <summary>
         /// Analyzes the given syntax node.
         /// If XML documentation exists for the node, no diagnostic is reported.
         /// If no XML documentation is found, a diagnostic for missing XML documentation is created and reported.
         /// </summary>
-        private void AnalyzeNode(SyntaxNodeAnalysisContext context, bool evented)
+        private void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
             SyntaxNode node = context.Node;
 
@@ -58,8 +56,8 @@
             }
 
             // Create and report the diagnostic
-            (Location loc, string name) = getLocationAndName();
-            Diagnostic diagnostic = Diagnostic.Create(Rule, loc, node.Kind(), name);
+            (Location loc, var name) = getLocationAndName();
+            var diagnostic = Diagnostic.Create(Rule, loc, node.Kind(), name);
             context.ReportDiagnostic(diagnostic);
 
             (Location, string) getLocationAndName()

--- a/DocGpt.Roslyn/DocGptCodeAction.cs
+++ b/DocGpt.Roslyn/DocGptCodeAction.cs
@@ -1,12 +1,12 @@
 ﻿namespace DocGpt
 {
-    using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.CodeActions;
-    using Microsoft.CodeAnalysis.Formatting;
-
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.Formatting;
 
     using Document = Microsoft.CodeAnalysis.Document;
 
@@ -56,7 +56,7 @@
             SyntaxNode root = await _doc.GetSyntaxRootAsync(cancellationToken);
             SyntaxNode node = root.FindNode(diagnosticSpan);
 
-            var (newNode, nodeToReplace) = await DocGptExecutor.AddXmlDocumentationAsync(node, cancellationToken);
+            (SyntaxNode newNode, SyntaxNode nodeToReplace) = await DocGptExecutor.AddXmlDocumentationAsync(node, cancellationToken);
 
             SyntaxNode newRoot = root.ReplaceNode(nodeToReplace, newNode);
 
@@ -82,7 +82,7 @@
             public override string Title { get; } = "Sends this entire member's definition (and body) to the defined OpenAI endpoint for summary text generation and applies the result.";
 
             /// <inheritdoc />
-            public override Task<object> GetPreviewAsync(CancellationToken cancellationToken) => Task.FromResult<object>(Title);
+            public override Task<object> GetPreviewAsync(CancellationToken cancellationToken) => Task.FromResult<object>(this.Title);
         }
     }
 }

--- a/DocGpt.Roslyn/DocGptCodeFixProvider.cs
+++ b/DocGpt.Roslyn/DocGptCodeFixProvider.cs
@@ -1,13 +1,13 @@
 ﻿namespace DocGpt
 {
-    using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.CodeFixes;
-    using Microsoft.CodeAnalysis.CSharp.Syntax;
-
     using System.Collections.Immutable;
     using System.Composition;
     using System.Linq;
     using System.Threading.Tasks;
+
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
 
     /// <summary>
     /// The doc gpt code fix provider.
@@ -18,25 +18,17 @@
         /// <summary>
         /// Gets the fixable diagnostic ids.
         /// </summary>
-        public sealed override ImmutableArray<string> FixableDiagnosticIds
-        {
-            get
-            {
-                return ImmutableArray.Create("CS1591",    // The diagnostic id of the XML Documentation an analyzer fired when XML doc gen is turned on but missing from a visible member
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("CS1591",    // The diagnostic id of the XML Documentation an analyzer fired when XML doc gen is turned on but missing from a visible member
                     "CD1606",   // Diagnostic from "CodeDocumentor" analyzer (https://marketplace.visualstudio.com/items?itemName=DanTurco.CodeDocumentor)
                 DocGptAnalyzer.DiagnosticId);
-            }
-        }
 
         /// <summary>
         /// Get the fix all provider.
         /// </summary>
         /// <returns>A FixAllProvider.</returns>
-        public sealed override FixAllProvider GetFixAllProvider()
-        {
+        public sealed override FixAllProvider GetFixAllProvider() =>
             // See https://github.com/dotnet/roslyn/blob/main/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
-            return WellKnownFixAllProviders.BatchFixer;
-        }
+            WellKnownFixAllProviders.BatchFixer;
 
         /// <summary>
         /// Registers the code fixes asynchronously.
@@ -47,7 +39,7 @@
         {
             SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
-            Diagnostic diagnostic = context.Diagnostics.FirstOrDefault(i => FixableDiagnosticIds.Contains(i.Id));
+            Diagnostic diagnostic = context.Diagnostics.FirstOrDefault(i => this.FixableDiagnosticIds.Contains(i.Id));
             if (diagnostic is null)
             {
                 return;
@@ -68,7 +60,7 @@
                 }
             }
 
-            string code = root.GetText().GetSubText(diagnosticSpan).ToString();
+            var code = root.GetText().GetSubText(diagnosticSpan).ToString();
 
             // Register a code action that will invoke the fix.
             context.RegisterCodeFix(new DocGptCodeAction(context.Document, diagnostic.Location), diagnostic);

--- a/DocGpt.Roslyn/DocGptRefactoringProvider.cs
+++ b/DocGpt.Roslyn/DocGptRefactoringProvider.cs
@@ -1,15 +1,15 @@
 ﻿namespace DocGpt
 {
-    using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.CodeRefactorings;
-    using Microsoft.CodeAnalysis.CSharp;
-    using Microsoft.CodeAnalysis.CSharp.Syntax;
-
     using System;
     using System.Composition;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeRefactorings;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
 
     /// <summary>
     /// The doc gpt code fix provider.

--- a/DocGpt.Roslyn/Helpers.cs
+++ b/DocGpt.Roslyn/Helpers.cs
@@ -1,12 +1,12 @@
 ﻿namespace DocGpt
 {
+    using System.Linq;
+
     using DocGpt.Options;
 
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
-
-    using System.Linq;
 
     internal static class Helpers
     {
@@ -24,6 +24,7 @@
             return node.WithLeadingTrivia(commentTrivia);
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0046:Convert to conditional expression", Justification = "Readability")]
         public static bool ShouldSkip(SyntaxNode node)
         {
             // Skip nodes that already have XML documentation

--- a/DocGpt.Roslyn/Options/DocGptOptions.cs
+++ b/DocGpt.Roslyn/Options/DocGptOptions.cs
@@ -1,8 +1,8 @@
 ﻿namespace DocGpt.Options
 {
-    using Azure.AI.OpenAI;
-
     using System;
+
+    using Azure.AI.OpenAI;
 
     /// <summary>
     /// Represents the configuration options for an OpenAI or Azure-based OpenAI service.
@@ -68,8 +68,8 @@
             {
                 _client =
                     _endpoint.Host.EndsWith("azure.com", StringComparison.OrdinalIgnoreCase)
-                    ? new OpenAIClient(_endpoint ?? throw new ArgumentNullException(nameof(Endpoint)), new Azure.AzureKeyCredential(_apiKey ?? throw new ArgumentNullException(nameof(ApiKey))))
-                    : new OpenAIClient(_apiKey ?? throw new ArgumentNullException(nameof(ApiKey)));
+                    ? new OpenAIClient(_endpoint ?? throw new ArgumentNullException(nameof(this.Endpoint)), new Azure.AzureKeyCredential(_apiKey ?? throw new ArgumentNullException(nameof(this.ApiKey))))
+                    : new OpenAIClient(_apiKey ?? throw new ArgumentNullException(nameof(this.ApiKey)));
             }
 
             return _client;

--- a/DocGpt.Test/AnalyzerTests.cs
+++ b/DocGpt.Test/AnalyzerTests.cs
@@ -1,11 +1,11 @@
 ﻿namespace DocGpt.Test;
 
+using System.Threading.Tasks;
+
 using DocGpt.Options;
 
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-using System.Threading.Tasks;
 
 using VerifyCS = CSharpAnalyzerVerifier<DocGptAnalyzer>;
 
@@ -22,7 +22,7 @@ public class AnalyzerTests
     [TestMethod]
     public async Task AnalyzerPasses_BlankFile()
     {
-        string test = @"";
+        var test = @"";
 
         await VerifyCS.VerifyAnalyzerAsync(test, DiagnosticResult.EmptyDiagnosticResults);
     }
@@ -34,7 +34,7 @@ public class AnalyzerTests
     [TestMethod]
     public async Task AnalyzerPasses_DocumentedClass()
     {
-        string test = @"
+        var test = @"
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -60,7 +60,7 @@ public class AnalyzerTests
     [TestMethod]
     public async Task AnalyzerThrows_ClassDecl()
     {
-        string test = @"
+        var test = @"
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -88,7 +88,7 @@ public class AnalyzerTests
     {
         DocGptOptions.Instance.UseValueForLiteralConstants = true;
 
-        string test = @"
+        var test = @"
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -118,7 +118,7 @@ public class AnalyzerTests
     {
         DocGptOptions.Instance.UseValueForLiteralConstants = false;
 
-        string test = @"
+        var test = @"
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -148,7 +148,7 @@ public class AnalyzerTests
     {
         DocGptOptions.Instance.OverridesBehavior = OverrideBehavior.UseInheritDoc;
 
-        string test = @"
+        var test = @"
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -185,7 +185,7 @@ public class AnalyzerTests
     {
         DocGptOptions.Instance.OverridesBehavior = OverrideBehavior.DoNotDocument;
 
-        string test = @"
+        var test = @"
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/DocGpt.Test/AnalyzerTests.cs
+++ b/DocGpt.Test/AnalyzerTests.cs
@@ -1,40 +1,40 @@
-﻿namespace DocGpt.Test
+﻿namespace DocGpt.Test;
+
+using DocGpt.Options;
+
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System.Threading.Tasks;
+
+using VerifyCS = CSharpAnalyzerVerifier<DocGptAnalyzer>;
+
+/// <summary>
+/// The doc gpt unit test.
+/// </summary>
+[TestClass]
+public class AnalyzerTests
 {
-    using DocGpt.Options;
+    /// <summary>
+    /// Analyzer the does not throw.
+    /// </summary>
+    /// <returns>A Task.</returns>
+    [TestMethod]
+    public async Task AnalyzerPasses_BlankFile()
+    {
+        string test = @"";
 
-    using Microsoft.CodeAnalysis.Testing;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-    using System.Threading.Tasks;
-
-    using VerifyCS = CSharpAnalyzerVerifier<DocGptAnalyzer>;
+        await VerifyCS.VerifyAnalyzerAsync(test, DiagnosticResult.EmptyDiagnosticResults);
+    }
 
     /// <summary>
-    /// The doc gpt unit test.
+    /// Analyzer the does not throw.
     /// </summary>
-    [TestClass]
-    public class AnalyzerTests
+    /// <returns>A Task.</returns>
+    [TestMethod]
+    public async Task AnalyzerPasses_DocumentedClass()
     {
-        /// <summary>
-        /// Analyzer the does not throw.
-        /// </summary>
-        /// <returns>A Task.</returns>
-        [TestMethod]
-        public async Task AnalyzerPasses_BlankFile()
-        {
-            string test = @"";
-
-            await VerifyCS.VerifyAnalyzerAsync(test, DiagnosticResult.EmptyDiagnosticResults);
-        }
-
-        /// <summary>
-        /// Analyzer the does not throw.
-        /// </summary>
-        /// <returns>A Task.</returns>
-        [TestMethod]
-        public async Task AnalyzerPasses_DocumentedClass()
-        {
-            string test = @"
+        string test = @"
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -50,17 +50,17 @@
         }
     }";
 
-            await VerifyCS.VerifyAnalyzerAsync(test, DiagnosticResult.EmptyDiagnosticResults);
-        }
+        await VerifyCS.VerifyAnalyzerAsync(test, DiagnosticResult.EmptyDiagnosticResults);
+    }
 
-        /// <summary>
-        /// Test method2.
-        /// </summary>
-        /// <returns>A Task.</returns>
-        [TestMethod]
-        public async Task AnalyzerThrows_ClassDecl()
-        {
-            string test = @"
+    /// <summary>
+    /// Test method2.
+    /// </summary>
+    /// <returns>A Task.</returns>
+    [TestMethod]
+    public async Task AnalyzerThrows_ClassDecl()
+    {
+        string test = @"
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -75,20 +75,20 @@
         }
     }";
 
-            DiagnosticResult expected = VerifyCS.Diagnostic(DocGptAnalyzer.Rule).WithSpan(11, 15, 11, 22).WithArguments("ClassDeclaration", "MyClass");
-            await VerifyCS.VerifyAnalyzerAsync(test, expected);
-        }
+        DiagnosticResult expected = VerifyCS.Diagnostic(DocGptAnalyzer.Rule).WithSpan(11, 15, 11, 22).WithArguments("ClassDeclaration", "MyClass");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
 
-        /// <summary>
-        /// Test method2.
-        /// </summary>
-        /// <returns>A Task.</returns>
-        [TestMethod]
-        public async Task AnalyzerThrows_ConstLiteralMember_UseValueForComment()
-        {
-            DocGptOptions.Instance.UseValueForLiteralConstants = true;
+    /// <summary>
+    /// Test method2.
+    /// </summary>
+    /// <returns>A Task.</returns>
+    [TestMethod]
+    public async Task AnalyzerThrows_ConstLiteralMember_UseValueForComment()
+    {
+        DocGptOptions.Instance.UseValueForLiteralConstants = true;
 
-            string test = @"
+        string test = @"
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -105,20 +105,20 @@
         }
     }";
 
-            DiagnosticResult expected = VerifyCS.Diagnostic(DocGptAnalyzer.Rule).WithSpan(14, 35, 14, 42).WithArguments("FieldDeclaration", "MyConst");
-            await VerifyCS.VerifyAnalyzerAsync(test, expected);
-        }
+        DiagnosticResult expected = VerifyCS.Diagnostic(DocGptAnalyzer.Rule).WithSpan(14, 35, 14, 42).WithArguments("FieldDeclaration", "MyConst");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
 
-        /// <summary>
-        /// Test method2.
-        /// </summary>
-        /// <returns>A Task.</returns>
-        [TestMethod]
-        public async Task AnalyzerThrows_ConstLiteralMember_DoNotUseValueForComment()
-        {
-            DocGptOptions.Instance.UseValueForLiteralConstants = false;
+    /// <summary>
+    /// Test method2.
+    /// </summary>
+    /// <returns>A Task.</returns>
+    [TestMethod]
+    public async Task AnalyzerThrows_ConstLiteralMember_DoNotUseValueForComment()
+    {
+        DocGptOptions.Instance.UseValueForLiteralConstants = false;
 
-            string test = @"
+        string test = @"
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -135,20 +135,20 @@
         }
     }";
 
-            DiagnosticResult expected = VerifyCS.Diagnostic(DocGptAnalyzer.Rule).WithSpan(14, 35, 14, 42).WithArguments("FieldDeclaration", "MyConst");
-            await VerifyCS.VerifyAnalyzerAsync(test, expected);
-        }
+        DiagnosticResult expected = VerifyCS.Diagnostic(DocGptAnalyzer.Rule).WithSpan(14, 35, 14, 42).WithArguments("FieldDeclaration", "MyConst");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
 
-        /// <summary>
-        /// Test method2.
-        /// </summary>
-        /// <returns>A Task.</returns>
-        [TestMethod]
-        public async Task AnalyzerThrows_Override_InheritDoc()
-        {
-            DocGptOptions.Instance.OverridesBehavior = OverrideBehavior.UseInheritDoc;
+    /// <summary>
+    /// Test method2.
+    /// </summary>
+    /// <returns>A Task.</returns>
+    [TestMethod]
+    public async Task AnalyzerThrows_Override_InheritDoc()
+    {
+        DocGptOptions.Instance.OverridesBehavior = OverrideBehavior.UseInheritDoc;
 
-            string test = @"
+        string test = @"
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -172,20 +172,20 @@
         }
     }";
 
-            DiagnosticResult expected = VerifyCS.Diagnostic(DocGptAnalyzer.Rule).WithSpan(21, 37, 21, 40).WithArguments("MethodDeclaration", "Foo");
-            await VerifyCS.VerifyAnalyzerAsync(test, expected);
-        }
+        DiagnosticResult expected = VerifyCS.Diagnostic(DocGptAnalyzer.Rule).WithSpan(21, 37, 21, 40).WithArguments("MethodDeclaration", "Foo");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
 
-        /// <summary>
-        /// Test method2.
-        /// </summary>
-        /// <returns>A Task.</returns>
-        [TestMethod]
-        public async Task AnalyzerPasses_Override_DoNotDocument()
-        {
-            DocGptOptions.Instance.OverridesBehavior = OverrideBehavior.DoNotDocument;
+    /// <summary>
+    /// Test method2.
+    /// </summary>
+    /// <returns>A Task.</returns>
+    [TestMethod]
+    public async Task AnalyzerPasses_Override_DoNotDocument()
+    {
+        DocGptOptions.Instance.OverridesBehavior = OverrideBehavior.DoNotDocument;
 
-            string test = @"
+        string test = @"
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -209,7 +209,6 @@
         }
     }";
 
-            await VerifyCS.VerifyAnalyzerAsync(test, DiagnosticResult.EmptyDiagnosticResults);
-        }
+        await VerifyCS.VerifyAnalyzerAsync(test, DiagnosticResult.EmptyDiagnosticResults);
     }
 }

--- a/DocGpt.Test/CodeFixTests.cs
+++ b/DocGpt.Test/CodeFixTests.cs
@@ -1,43 +1,33 @@
-﻿namespace DocGpt.Test
+﻿namespace DocGpt.Test;
+
+using DocGpt.Options;
+
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System;
+using System.Threading.Tasks;
+
+using VerifyCS = CSharpCodeFixVerifier<DocGptAnalyzer, DocGptCodeFixProvider>;
+
+/// <summary>
+/// The doc gpt unit test.
+/// </summary>
+[TestClass]
+public class CodeFixTests
 {
-    using DocGpt.Options;
-
-    using Microsoft.CodeAnalysis.Testing;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-    using System;
-    using System.Threading.Tasks;
-
-    using VerifyCS = CSharpCodeFixVerifier<DocGptAnalyzer, DocGptCodeFixProvider>;
+    public TestContext TestContext { get; set; }
 
     /// <summary>
-    /// The doc gpt unit test.
+    /// Analyzers the throws class decl.
     /// </summary>
-    [TestClass]
-    public class CodeFixTests
+    /// <returns>A Task.</returns>
+    [TestMethod]
+    public async Task CodeFix_DGPT001_Constant_UseValue()
     {
-        public TestContext TestContext { get; set; }
+        DocGptOptions.Instance.UseValueForLiteralConstants = true;
 
-        [AssemblyInitialize]
-        public static void AsmInit(TestContext _)
-        {
-            DocGptOptions.Instance.Endpoint = new Uri("http://localhost:5000");
-            DocGptOptions.Instance.ApiKey = "foo";
-            DocGptOptions.Instance.ModelDeploymentName = "foo";
-        }
-
-        private const string ApiKey = "foo";
-
-        /// <summary>
-        /// Analyzers the throws class decl.
-        /// </summary>
-        /// <returns>A Task.</returns>
-        [TestMethod]
-        public async Task CodeFix_DGPT001_Constant_UseValue()
-        {
-            DocGptOptions.Instance.UseValueForLiteralConstants = true;
-
-            string test = @"
+        string test = @"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -54,7 +44,7 @@ namespace ConsoleApplication1
     }
 }";
 
-            string fixd = @"
+        string fixd = @"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -72,73 +62,73 @@ namespace ConsoleApplication1
     }
 }";
 
-            DiagnosticResult expected = VerifyCS.Diagnostic(DocGptAnalyzer.Rule).WithSpan(14, 31, 14, 38).WithArguments("FieldDeclaration", "MyConst");
+        DiagnosticResult expected = VerifyCS.Diagnostic(DocGptAnalyzer.Rule).WithSpan(14, 31, 14, 38).WithArguments("FieldDeclaration", "MyConst");
+        await VerifyCS.VerifyCodeFixAsync(test, expected, fixd);
+    }
+
+    /// <summary>
+    /// Analyzers the throws class decl.
+    /// </summary>
+    /// <returns>A Task.</returns>
+    [TestMethod]
+    public async Task CodeFix_DGPT001_Constant_DoNotUseValue()
+    {
+        DocGptOptions.Instance.UseValueForLiteralConstants = false;
+
+        string test = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Diagnostics;
+
+namespace ConsoleApplication1
+{
+    /// <summary></summary>
+    class MyClass
+    {
+        internal const string MyConst = ""Foo"";
+    }
+}";
+
+        string fixd = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Diagnostics;
+
+namespace ConsoleApplication1
+{
+    /// <summary></summary>
+    class MyClass
+    {
+        internal const string MyConst = ""Foo"";
+    }
+}";
+
+        DiagnosticResult expected = VerifyCS.Diagnostic(DocGptAnalyzer.Rule).WithSpan(14, 31, 14, 38).WithArguments("FieldDeclaration", "MyConst");
+        try
+        {
             await VerifyCS.VerifyCodeFixAsync(test, expected, fixd);
         }
-
-        /// <summary>
-        /// Analyzers the throws class decl.
-        /// </summary>
-        /// <returns>A Task.</returns>
-        [TestMethod]
-        public async Task CodeFix_DGPT001_Constant_DoNotUseValue()
+        catch (Exception e)
         {
-            DocGptOptions.Instance.UseValueForLiteralConstants = false;
-
-            string test = @"
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Diagnostics;
-
-namespace ConsoleApplication1
-{
-    /// <summary></summary>
-    class MyClass
-    {
-        internal const string MyConst = ""Foo"";
-    }
-}";
-
-            string fixd = @"
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Diagnostics;
-
-namespace ConsoleApplication1
-{
-    /// <summary></summary>
-    class MyClass
-    {
-        internal const string MyConst = ""Foo"";
-    }
-}";
-
-            DiagnosticResult expected = VerifyCS.Diagnostic(DocGptAnalyzer.Rule).WithSpan(14, 31, 14, 38).WithArguments("FieldDeclaration", "MyConst");
-            try
-            {
-                await VerifyCS.VerifyCodeFixAsync(test, expected, fixd);
-            }
-            catch (Exception e)
-            {
-                Assert.IsInstanceOfType<Azure.RequestFailedException>(e);
-            }
+            Assert.IsInstanceOfType<Azure.RequestFailedException>(e);
         }
+    }
 
-        /// <summary>
-        /// Analyzers the throws class decl.
-        /// </summary>
-        /// <returns>A Task.</returns>
-        [TestMethod]
-        public async Task CodeFix_DGPT001_Override_UseInheritDoc()
-        {
-            DocGptOptions.Instance.OverridesBehavior = OverrideBehavior.UseInheritDoc;
-            string test = @"
+    /// <summary>
+    /// Analyzers the throws class decl.
+    /// </summary>
+    /// <returns>A Task.</returns>
+    [TestMethod]
+    public async Task CodeFix_DGPT001_Override_UseInheritDoc()
+    {
+        DocGptOptions.Instance.OverridesBehavior = OverrideBehavior.UseInheritDoc;
+        string test = @"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -162,7 +152,7 @@ namespace ConsoleApplication1
     }
 }";
 
-            string fixd = @"
+        string fixd = @"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -187,136 +177,136 @@ namespace ConsoleApplication1
     }
 }";
 
-            DiagnosticResult expected = VerifyCS.Diagnostic(DocGptAnalyzer.Rule).WithSpan(21, 33, 21, 44).WithArguments("MethodDeclaration", "DoSomething");
+        DiagnosticResult expected = VerifyCS.Diagnostic(DocGptAnalyzer.Rule).WithSpan(21, 33, 21, 44).WithArguments("MethodDeclaration", "DoSomething");
+        await VerifyCS.VerifyCodeFixAsync(test, expected, fixd);
+    }
+
+    /// <summary>
+    /// Analyzers the throws class decl.
+    /// </summary>
+    /// <returns>A Task.</returns>
+    [TestMethod]
+    public async Task CodeFix_DGPT001_Override_DoNotDocument()
+    {
+        DocGptOptions.Instance.OverridesBehavior = OverrideBehavior.DoNotDocument;
+
+        string test = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Diagnostics;
+
+namespace ConsoleApplication1
+{
+    /// <summary></summary>
+    class MyClass
+    {
+        /// <summary>Foo</summary>
+        protected virtual bool DoSomething() => true;
+    }
+
+    /// <summary></summary>
+    class MyDerivedClass : MyClass
+    {
+        protected override bool DoSomething() => false;
+    }
+}";
+
+        string fixd = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Diagnostics;
+
+namespace ConsoleApplication1
+{
+    /// <summary></summary>
+    class MyClass
+    {
+        /// <summary>Foo</summary>
+        protected virtual bool DoSomething() => true;
+    }
+
+    /// <summary></summary>
+    class MyDerivedClass : MyClass
+    {
+        protected override bool DoSomething() => false;
+    }
+}";
+
+        await VerifyCS.VerifyCodeFixAsync(test, DiagnosticResult.EmptyDiagnosticResults, fixd);
+    }
+
+    /// <summary>
+    /// Analyzers the throws class decl.
+    /// </summary>
+    /// <returns>A Task.</returns>
+    [TestMethod]
+    [Ignore("Manual activation required; needs live API execution")]
+    public async Task CodeFix_DGPT001_Override_UseGpt()
+    {
+        DocGptOptions.Instance.OverridesBehavior = OverrideBehavior.GptSummarize;
+
+        string test = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Diagnostics;
+
+namespace ConsoleApplication1
+{
+    /// <summary></summary>
+    class MyClass
+    {
+        /// <summary>Foo</summary>
+        protected virtual bool DoSomething() => true;
+    }
+
+    /// <summary></summary>
+    class MyDerivedClass : MyClass
+    {
+        protected override bool DoSomething() => false;
+    }
+}";
+
+        string fixd = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Diagnostics;
+
+namespace ConsoleApplication1
+{
+    /// <summary></summary>
+    class MyClass
+    {
+        /// <summary>Foo</summary>
+        protected virtual bool DoSomething() => true;
+    }
+
+    /// <summary></summary>
+    class MyDerivedClass : MyClass
+    {
+        protected override bool DoSomething() => false;
+    }
+}";
+
+        DiagnosticResult expected = VerifyCS.Diagnostic(DocGptAnalyzer.Rule).WithSpan(21, 33, 21, 44).WithArguments("MethodDeclaration", "DoSomething");
+        try
+        {
             await VerifyCS.VerifyCodeFixAsync(test, expected, fixd);
         }
-
-        /// <summary>
-        /// Analyzers the throws class decl.
-        /// </summary>
-        /// <returns>A Task.</returns>
-        [TestMethod]
-        public async Task CodeFix_DGPT001_Override_DoNotDocument()
+        catch (Exception e)
         {
-            DocGptOptions.Instance.OverridesBehavior = OverrideBehavior.DoNotDocument;
-
-            string test = @"
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Diagnostics;
-
-namespace ConsoleApplication1
-{
-    /// <summary></summary>
-    class MyClass
-    {
-        /// <summary>Foo</summary>
-        protected virtual bool DoSomething() => true;
-    }
-
-    /// <summary></summary>
-    class MyDerivedClass : MyClass
-    {
-        protected override bool DoSomething() => false;
-    }
-}";
-
-            string fixd = @"
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Diagnostics;
-
-namespace ConsoleApplication1
-{
-    /// <summary></summary>
-    class MyClass
-    {
-        /// <summary>Foo</summary>
-        protected virtual bool DoSomething() => true;
-    }
-
-    /// <summary></summary>
-    class MyDerivedClass : MyClass
-    {
-        protected override bool DoSomething() => false;
-    }
-}";
-
-            await VerifyCS.VerifyCodeFixAsync(test, DiagnosticResult.EmptyDiagnosticResults, fixd);
-        }
-
-        /// <summary>
-        /// Analyzers the throws class decl.
-        /// </summary>
-        /// <returns>A Task.</returns>
-        [TestMethod]
-        public async Task CodeFix_DGPT001_Override_UseGpt()
-        {
-            DocGptOptions.Instance.OverridesBehavior = OverrideBehavior.GptSummarize;
-
-            string test = @"
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Diagnostics;
-
-namespace ConsoleApplication1
-{
-    /// <summary></summary>
-    class MyClass
-    {
-        /// <summary>Foo</summary>
-        protected virtual bool DoSomething() => true;
-    }
-
-    /// <summary></summary>
-    class MyDerivedClass : MyClass
-    {
-        protected override bool DoSomething() => false;
-    }
-}";
-
-            string fixd = @"
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Diagnostics;
-
-namespace ConsoleApplication1
-{
-    /// <summary></summary>
-    class MyClass
-    {
-        /// <summary>Foo</summary>
-        protected virtual bool DoSomething() => true;
-    }
-
-    /// <summary></summary>
-    class MyDerivedClass : MyClass
-    {
-        protected override bool DoSomething() => false;
-    }
-}";
-
-            DiagnosticResult expected = VerifyCS.Diagnostic(DocGptAnalyzer.Rule).WithSpan(21, 33, 21, 44).WithArguments("MethodDeclaration", "DoSomething");
-            try
-            {
-                await VerifyCS.VerifyCodeFixAsync(test, expected, fixd);
-            }
-            catch (Exception e)
-            {
-                Assert.IsInstanceOfType<Azure.RequestFailedException>(e);
-            }
+            Assert.IsInstanceOfType<Azure.RequestFailedException>(e);
         }
     }
 }

--- a/DocGpt.Test/DocGpt.Test.csproj
+++ b/DocGpt.Test/DocGpt.Test.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.12" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-preview-23577-04" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0-preview.23623.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0-preview.23623.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.9.0-2.final" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.17" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.9.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest" Version="1.1.1" />

--- a/DocGpt.Test/GptSetup.cs
+++ b/DocGpt.Test/GptSetup.cs
@@ -1,7 +1,14 @@
 ﻿namespace DocGpt.Test;
 
+using System.Threading.Tasks;
+
+using Azure;
+
 using DocGpt.Options;
 
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 [TestClass]
@@ -13,5 +20,29 @@ internal static class GptSetup
         DocGptOptions.Instance.Endpoint = new("https://api.openai.com");
         DocGptOptions.Instance.ApiKey = "...";
         DocGptOptions.Instance.ModelDeploymentName = "gpt-3.5-turbo-16k";
+    }
+}
+
+public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
+    where TAnalyzer : DiagnosticAnalyzer, new()
+    where TCodeFix : CodeFixProvider, new()
+{
+    public static async Task VerifyGptDidSomethingAsync(DiagnosticResult diag, string test)
+    {
+        try
+        {
+            await VerifyCodeFixAsync(test, diag, test);
+
+            Assert.Fail("Should have failed the CodeFix verifier");
+        }
+        catch (AssertFailedException e)
+        {
+            // We expect any other assertion message because GPT will have populated the doc comment with a value; this is non-deterministic, so we pass as long as input != output
+            Assert.AreNotEqual("Should have failed the CodeFix verifier", e.Message);
+        }
+        catch (RequestFailedException e)
+        {
+            Assert.Fail("Did you forget to put your OpenAI Key into GptSetup.cs? {0}", e);
+        }
     }
 }

--- a/DocGpt.Test/GptSetup.cs
+++ b/DocGpt.Test/GptSetup.cs
@@ -1,0 +1,17 @@
+﻿namespace DocGpt.Test;
+
+using DocGpt.Options;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+internal static class GptSetup
+{
+    [AssemblyInitialize]
+    public static void AsmInit(TestContext _)
+    {
+        DocGptOptions.Instance.Endpoint = new("https://api.openai.com");
+        DocGptOptions.Instance.ApiKey = "...";
+        DocGptOptions.Instance.ModelDeploymentName = "gpt-3.5-turbo-16k";
+    }
+}

--- a/DocGpt.Test/RefactoringTests.cs
+++ b/DocGpt.Test/RefactoringTests.cs
@@ -1,34 +1,23 @@
-﻿
-namespace DocGpt.Test
+﻿namespace DocGpt.Test;
+
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using RefactorCS = CSharpCodeRefactoringVerifier<DocGptRefactoringProvider>;
+
+[TestClass]
+[Ignore("Manual activation required; needs live API execution")]
+public class RefactoringTests : RefactorCS.Test
 {
-    using DocGpt.Options;
-
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-    using System.Threading.Tasks;
-
-    using RefactorCS = CSharpCodeRefactoringVerifier<DocGptRefactoringProvider>;
-
-    [TestClass]
-    [Ignore("Manual activation required; needs live API execution")]
-    public class RefactoringTests : RefactorCS.Test
+    /// <summary>
+    /// Analyzers the throws class decl.
+    /// </summary>
+    /// <returns>A Task.</returns>
+    [TestMethod]
+    public async Task Refactor_Private_Member_Variable()
     {
-        [ClassInitialize]
-        public static void ClassInit()
-        {
-            //DocGptOptions.Instance.Endpoint = new("https://api.openai.com");
-            //DocGptOptions.Instance.ApiKey = "TODO";
-            //DocGptOptions.Instance.ModelDeploymentName = "gpt-3.5-turbo-16k";
-        }
-
-        /// <summary>
-        /// Analyzers the throws class decl.
-        /// </summary>
-        /// <returns>A Task.</returns>
-        [TestMethod]
-        public async Task Refactor_Private_Member_Variable()
-        {
-            string test = @"
+        string test = @"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -45,7 +34,7 @@ namespace ConsoleApplication1
     }
 }";
 
-            string fixd = @"
+        string fixd = @"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -65,17 +54,17 @@ namespace ConsoleApplication1
     }
 }";
 
-            await RefactorCS.VerifyRefactoringAsync(test, fixd);
-        }
+        await RefactorCS.VerifyRefactoringAsync(test, fixd);
+    }
 
-        /// <summary>
-        /// Analyzers the throws class decl.
-        /// </summary>
-        /// <returns>A Task.</returns>
-        [TestMethod]
-        public async Task Refactor_Private_Member_Variable_Trigger_on_Name()
-        {
-            string test = @"
+    /// <summary>
+    /// Analyzers the throws class decl.
+    /// </summary>
+    /// <returns>A Task.</returns>
+    [TestMethod]
+    public async Task Refactor_Private_Member_Variable_Trigger_on_Name()
+    {
+        string test = @"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -92,7 +81,7 @@ namespace ConsoleApplication1
     }
 }";
 
-            string fixd = @"
+        string fixd = @"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -112,7 +101,6 @@ namespace ConsoleApplication1
     }
 }";
 
-            await RefactorCS.VerifyRefactoringAsync(test, fixd);
-        }
+        await RefactorCS.VerifyRefactoringAsync(test, fixd);
     }
 }

--- a/DocGpt.Test/RefactoringTests.cs
+++ b/DocGpt.Test/RefactoringTests.cs
@@ -17,7 +17,7 @@ public class RefactoringTests : RefactorCS.Test
     [TestMethod]
     public async Task Refactor_Private_Member_Variable()
     {
-        string test = @"
+        var test = @"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -34,7 +34,7 @@ namespace ConsoleApplication1
     }
 }";
 
-        string fixd = @"
+        var fixd = @"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -64,7 +64,7 @@ namespace ConsoleApplication1
     [TestMethod]
     public async Task Refactor_Private_Member_Variable_Trigger_on_Name()
     {
-        string test = @"
+        var test = @"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -81,7 +81,7 @@ namespace ConsoleApplication1
     }
 }";
 
-        string fixd = @"
+        var fixd = @"
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/DocGpt.Test/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
+++ b/DocGpt.Test/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
@@ -1,26 +1,25 @@
-﻿namespace DocGpt.Test
+﻿namespace DocGpt.Test;
+
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+public static partial class CSharpAnalyzerVerifier<TAnalyzer>
+    where TAnalyzer : DiagnosticAnalyzer, new()
 {
-    using Microsoft.CodeAnalysis.CSharp.Testing;
-    using Microsoft.CodeAnalysis.Diagnostics;
-    using Microsoft.CodeAnalysis.Testing.Verifiers;
-
-    public static partial class CSharpAnalyzerVerifier<TAnalyzer>
-        where TAnalyzer : DiagnosticAnalyzer, new()
+    public class Test : CSharpAnalyzerTest<TAnalyzer, MSTestVerifier>
     {
-        public class Test : CSharpAnalyzerTest<TAnalyzer, MSTestVerifier>
+        public Test()
         {
-            public Test()
+            SolutionTransforms.Add((solution, projectId) =>
             {
-                SolutionTransforms.Add((solution, projectId) =>
-                {
-                    var compilationOptions = solution.GetProject(projectId).CompilationOptions;
-                    compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
-                        compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings));
-                    solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
+                var compilationOptions = solution.GetProject(projectId).CompilationOptions;
+                compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
+                    compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings));
+                solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
 
-                    return solution;
-                });
-            }
+                return solution;
+            });
         }
     }
 }

--- a/DocGpt.Test/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
+++ b/DocGpt.Test/Verifiers/CSharpAnalyzerVerifier`1+Test.cs
@@ -11,9 +11,9 @@ public static partial class CSharpAnalyzerVerifier<TAnalyzer>
     {
         public Test()
         {
-            SolutionTransforms.Add((solution, projectId) =>
+            this.SolutionTransforms.Add((solution, projectId) =>
             {
-                var compilationOptions = solution.GetProject(projectId).CompilationOptions;
+                Microsoft.CodeAnalysis.CompilationOptions compilationOptions = solution.GetProject(projectId).CompilationOptions;
                 compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
                     compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings));
                 solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);

--- a/DocGpt.Test/Verifiers/CSharpAnalyzerVerifier`1.cs
+++ b/DocGpt.Test/Verifiers/CSharpAnalyzerVerifier`1.cs
@@ -1,13 +1,13 @@
 ﻿namespace DocGpt.Test;
 
+using System.Threading;
+using System.Threading.Tasks;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
-
-using System.Threading;
-using System.Threading.Tasks;
 
 public static partial class CSharpAnalyzerVerifier<TAnalyzer>
     where TAnalyzer : DiagnosticAnalyzer, new()

--- a/DocGpt.Test/Verifiers/CSharpAnalyzerVerifier`1.cs
+++ b/DocGpt.Test/Verifiers/CSharpAnalyzerVerifier`1.cs
@@ -1,39 +1,38 @@
-﻿namespace DocGpt.Test
+﻿namespace DocGpt.Test;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+using System.Threading;
+using System.Threading.Tasks;
+
+public static partial class CSharpAnalyzerVerifier<TAnalyzer>
+    where TAnalyzer : DiagnosticAnalyzer, new()
 {
-    using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.CSharp.Testing;
-    using Microsoft.CodeAnalysis.Diagnostics;
-    using Microsoft.CodeAnalysis.Testing;
-    using Microsoft.CodeAnalysis.Testing.Verifiers;
+    /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic()"/>
+    public static DiagnosticResult Diagnostic()
+        => CSharpAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic();
 
-    using System.Threading;
-    using System.Threading.Tasks;
+    /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic(string)"/>
+    public static DiagnosticResult Diagnostic(string diagnosticId)
+        => CSharpAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic(diagnosticId);
 
-    public static partial class CSharpAnalyzerVerifier<TAnalyzer>
-        where TAnalyzer : DiagnosticAnalyzer, new()
+    /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic(DiagnosticDescriptor)"/>
+    public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
+        => CSharpAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic(descriptor);
+
+    /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
+    public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
     {
-        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic()"/>
-        public static DiagnosticResult Diagnostic()
-            => CSharpAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic();
-
-        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic(string)"/>
-        public static DiagnosticResult Diagnostic(string diagnosticId)
-            => CSharpAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic(diagnosticId);
-
-        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.Diagnostic(DiagnosticDescriptor)"/>
-        public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
-            => CSharpAnalyzerVerifier<TAnalyzer, MSTestVerifier>.Diagnostic(descriptor);
-
-        /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
-        public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+        var test = new Test
         {
-            var test = new Test
-            {
-                TestCode = source,
-            };
+            TestCode = source,
+        };
 
-            test.ExpectedDiagnostics.AddRange(expected);
-            await test.RunAsync(CancellationToken.None);
-        }
+        test.ExpectedDiagnostics.AddRange(expected);
+        await test.RunAsync(CancellationToken.None);
     }
 }

--- a/DocGpt.Test/Verifiers/CSharpCodeFixVerifier`2+Test.cs
+++ b/DocGpt.Test/Verifiers/CSharpCodeFixVerifier`2+Test.cs
@@ -13,9 +13,9 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
     {
         public Test()
         {
-            SolutionTransforms.Add((solution, projectId) =>
+            this.SolutionTransforms.Add((solution, projectId) =>
             {
-                var compilationOptions = solution.GetProject(projectId).CompilationOptions;
+                Microsoft.CodeAnalysis.CompilationOptions compilationOptions = solution.GetProject(projectId).CompilationOptions;
                 compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
                     compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings));
                 solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);

--- a/DocGpt.Test/Verifiers/CSharpCodeFixVerifier`2+Test.cs
+++ b/DocGpt.Test/Verifiers/CSharpCodeFixVerifier`2+Test.cs
@@ -1,28 +1,27 @@
-﻿namespace DocGpt.Test
+﻿namespace DocGpt.Test;
+
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
+    where TAnalyzer : DiagnosticAnalyzer, new()
+    where TCodeFix : CodeFixProvider, new()
 {
-    using Microsoft.CodeAnalysis.CodeFixes;
-    using Microsoft.CodeAnalysis.CSharp.Testing;
-    using Microsoft.CodeAnalysis.Diagnostics;
-    using Microsoft.CodeAnalysis.Testing.Verifiers;
-
-    public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
-        where TAnalyzer : DiagnosticAnalyzer, new()
-        where TCodeFix : CodeFixProvider, new()
+    public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, MSTestVerifier>
     {
-        public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, MSTestVerifier>
+        public Test()
         {
-            public Test()
+            SolutionTransforms.Add((solution, projectId) =>
             {
-                SolutionTransforms.Add((solution, projectId) =>
-                {
-                    var compilationOptions = solution.GetProject(projectId).CompilationOptions;
-                    compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
-                        compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings));
-                    solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
+                var compilationOptions = solution.GetProject(projectId).CompilationOptions;
+                compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
+                    compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings));
+                solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
 
-                    return solution;
-                });
-            }
+                return solution;
+            });
         }
     }
 }

--- a/DocGpt.Test/Verifiers/CSharpCodeFixVerifier`2.cs
+++ b/DocGpt.Test/Verifiers/CSharpCodeFixVerifier`2.cs
@@ -1,14 +1,14 @@
 ﻿namespace DocGpt.Test;
 
+using System.Threading;
+using System.Threading.Tasks;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
-
-using System.Threading;
-using System.Threading.Tasks;
 
 public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
     where TAnalyzer : DiagnosticAnalyzer, new()

--- a/DocGpt.Test/Verifiers/CSharpCodeFixVerifier`2.cs
+++ b/DocGpt.Test/Verifiers/CSharpCodeFixVerifier`2.cs
@@ -1,62 +1,61 @@
-﻿namespace DocGpt.Test
+﻿namespace DocGpt.Test;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+using System.Threading;
+using System.Threading.Tasks;
+
+public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
+    where TAnalyzer : DiagnosticAnalyzer, new()
+    where TCodeFix : CodeFixProvider, new()
 {
-    using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.CodeFixes;
-    using Microsoft.CodeAnalysis.CSharp.Testing;
-    using Microsoft.CodeAnalysis.Diagnostics;
-    using Microsoft.CodeAnalysis.Testing;
-    using Microsoft.CodeAnalysis.Testing.Verifiers;
+    /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic()"/>
+    public static DiagnosticResult Diagnostic()
+        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, MSTestVerifier>.Diagnostic();
 
-    using System.Threading;
-    using System.Threading.Tasks;
+    /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic(string)"/>
+    public static DiagnosticResult Diagnostic(string diagnosticId)
+        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, MSTestVerifier>.Diagnostic(diagnosticId);
 
-    public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
-        where TAnalyzer : DiagnosticAnalyzer, new()
-        where TCodeFix : CodeFixProvider, new()
+    /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic(DiagnosticDescriptor)"/>
+    public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
+        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, MSTestVerifier>.Diagnostic(descriptor);
+
+    /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
+    public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
     {
-        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic()"/>
-        public static DiagnosticResult Diagnostic()
-            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, MSTestVerifier>.Diagnostic();
-
-        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic(string)"/>
-        public static DiagnosticResult Diagnostic(string diagnosticId)
-            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, MSTestVerifier>.Diagnostic(diagnosticId);
-
-        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.Diagnostic(DiagnosticDescriptor)"/>
-        public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
-            => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, MSTestVerifier>.Diagnostic(descriptor);
-
-        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyAnalyzerAsync(string, DiagnosticResult[])"/>
-        public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+        var test = new Test
         {
-            var test = new Test
-            {
-                TestCode = source,
-            };
+            TestCode = source,
+        };
 
-            test.ExpectedDiagnostics.AddRange(expected);
-            await test.RunAsync(CancellationToken.None);
-        }
+        test.ExpectedDiagnostics.AddRange(expected);
+        await test.RunAsync(CancellationToken.None);
+    }
 
-        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, string)"/>
-        public static async Task VerifyCodeFixAsync(string source, string fixedSource)
-            => await VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
+    /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, string)"/>
+    public static async Task VerifyCodeFixAsync(string source, string fixedSource)
+        => await VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
 
-        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult, string)"/>
-        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
-            => await VerifyCodeFixAsync(source, [expected], fixedSource);
+    /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult, string)"/>
+    public static async Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
+        => await VerifyCodeFixAsync(source, [expected], fixedSource);
 
-        /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult[], string)"/>
-        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)
+    /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult[], string)"/>
+    public static async Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)
+    {
+        var test = new Test
         {
-            var test = new Test
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-            };
+            TestCode = source,
+            FixedCode = fixedSource,
+        };
 
-            test.ExpectedDiagnostics.AddRange(expected);
-            await test.RunAsync(CancellationToken.None);
-        }
+        test.ExpectedDiagnostics.AddRange(expected);
+        await test.RunAsync(CancellationToken.None);
     }
 }

--- a/DocGpt.Test/Verifiers/CSharpCodeRefactoringVerifier`1+Test.cs
+++ b/DocGpt.Test/Verifiers/CSharpCodeRefactoringVerifier`1+Test.cs
@@ -1,26 +1,25 @@
-﻿namespace DocGpt.Test
+﻿namespace DocGpt.Test;
+
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+public static partial class CSharpCodeRefactoringVerifier<TCodeRefactoring>
+    where TCodeRefactoring : CodeRefactoringProvider, new()
 {
-    using Microsoft.CodeAnalysis.CodeRefactorings;
-    using Microsoft.CodeAnalysis.CSharp.Testing;
-    using Microsoft.CodeAnalysis.Testing.Verifiers;
-
-    public static partial class CSharpCodeRefactoringVerifier<TCodeRefactoring>
-        where TCodeRefactoring : CodeRefactoringProvider, new()
+    public class Test : CSharpCodeRefactoringTest<TCodeRefactoring, MSTestVerifier>
     {
-        public class Test : CSharpCodeRefactoringTest<TCodeRefactoring, MSTestVerifier>
+        public Test()
         {
-            public Test()
+            SolutionTransforms.Add((solution, projectId) =>
             {
-                SolutionTransforms.Add((solution, projectId) =>
-                {
-                    var compilationOptions = solution.GetProject(projectId).CompilationOptions;
-                    compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
-                        compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings));
-                    solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
+                var compilationOptions = solution.GetProject(projectId).CompilationOptions;
+                compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
+                    compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings));
+                solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
 
-                    return solution;
-                });
-            }
+                return solution;
+            });
         }
     }
 }

--- a/DocGpt.Test/Verifiers/CSharpCodeRefactoringVerifier`1+Test.cs
+++ b/DocGpt.Test/Verifiers/CSharpCodeRefactoringVerifier`1+Test.cs
@@ -11,9 +11,9 @@ public static partial class CSharpCodeRefactoringVerifier<TCodeRefactoring>
     {
         public Test()
         {
-            SolutionTransforms.Add((solution, projectId) =>
+            this.SolutionTransforms.Add((solution, projectId) =>
             {
-                var compilationOptions = solution.GetProject(projectId).CompilationOptions;
+                Microsoft.CodeAnalysis.CompilationOptions compilationOptions = solution.GetProject(projectId).CompilationOptions;
                 compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(
                     compilationOptions.SpecificDiagnosticOptions.SetItems(CSharpVerifierHelper.NullableWarnings));
                 solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);

--- a/DocGpt.Test/Verifiers/CSharpCodeRefactoringVerifier`1.cs
+++ b/DocGpt.Test/Verifiers/CSharpCodeRefactoringVerifier`1.cs
@@ -1,37 +1,36 @@
-﻿namespace DocGpt.Test
+﻿namespace DocGpt.Test;
+
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.Testing;
+
+using System.Threading;
+using System.Threading.Tasks;
+
+public static partial class CSharpCodeRefactoringVerifier<TCodeRefactoring>
+    where TCodeRefactoring : CodeRefactoringProvider, new()
 {
-    using Microsoft.CodeAnalysis.CodeRefactorings;
-    using Microsoft.CodeAnalysis.Testing;
-
-    using System.Threading;
-    using System.Threading.Tasks;
-
-    public static partial class CSharpCodeRefactoringVerifier<TCodeRefactoring>
-        where TCodeRefactoring : CodeRefactoringProvider, new()
+    /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, string)"/>
+    public static async Task VerifyRefactoringAsync(string source, string fixedSource)
     {
-        /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, string)"/>
-        public static async Task VerifyRefactoringAsync(string source, string fixedSource)
-        {
-            await VerifyRefactoringAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
-        }
+        await VerifyRefactoringAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
+    }
 
-        /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, DiagnosticResult, string)"/>
-        public static async Task VerifyRefactoringAsync(string source, DiagnosticResult expected, string fixedSource)
-        {
-            await VerifyRefactoringAsync(source, [expected], fixedSource);
-        }
+    /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, DiagnosticResult, string)"/>
+    public static async Task VerifyRefactoringAsync(string source, DiagnosticResult expected, string fixedSource)
+    {
+        await VerifyRefactoringAsync(source, [expected], fixedSource);
+    }
 
-        /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, DiagnosticResult[], string)"/>
-        public static async Task VerifyRefactoringAsync(string source, DiagnosticResult[] expected, string fixedSource)
+    /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, DiagnosticResult[], string)"/>
+    public static async Task VerifyRefactoringAsync(string source, DiagnosticResult[] expected, string fixedSource)
+    {
+        var test = new Test
         {
-            var test = new Test
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-            };
+            TestCode = source,
+            FixedCode = fixedSource,
+        };
 
-            test.ExpectedDiagnostics.AddRange(expected);
-            await test.RunAsync(CancellationToken.None);
-        }
+        test.ExpectedDiagnostics.AddRange(expected);
+        await test.RunAsync(CancellationToken.None);
     }
 }

--- a/DocGpt.Test/Verifiers/CSharpCodeRefactoringVerifier`1.cs
+++ b/DocGpt.Test/Verifiers/CSharpCodeRefactoringVerifier`1.cs
@@ -1,25 +1,19 @@
 ﻿namespace DocGpt.Test;
 
-using Microsoft.CodeAnalysis.CodeRefactorings;
-using Microsoft.CodeAnalysis.Testing;
-
 using System.Threading;
 using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.Testing;
 
 public static partial class CSharpCodeRefactoringVerifier<TCodeRefactoring>
     where TCodeRefactoring : CodeRefactoringProvider, new()
 {
     /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, string)"/>
-    public static async Task VerifyRefactoringAsync(string source, string fixedSource)
-    {
-        await VerifyRefactoringAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
-    }
+    public static async Task VerifyRefactoringAsync(string source, string fixedSource) => await VerifyRefactoringAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
 
     /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, DiagnosticResult, string)"/>
-    public static async Task VerifyRefactoringAsync(string source, DiagnosticResult expected, string fixedSource)
-    {
-        await VerifyRefactoringAsync(source, [expected], fixedSource);
-    }
+    public static async Task VerifyRefactoringAsync(string source, DiagnosticResult expected, string fixedSource) => await VerifyRefactoringAsync(source, [expected], fixedSource);
 
     /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, DiagnosticResult[], string)"/>
     public static async Task VerifyRefactoringAsync(string source, DiagnosticResult[] expected, string fixedSource)

--- a/DocGpt.Test/Verifiers/CSharpVerifierHelper.cs
+++ b/DocGpt.Test/Verifiers/CSharpVerifierHelper.cs
@@ -1,10 +1,10 @@
 ﻿namespace DocGpt.Test;
 
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-
 using System;
 using System.Collections.Immutable;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 internal static class CSharpVerifierHelper
 {
@@ -20,8 +20,8 @@ internal static class CSharpVerifierHelper
     private static ImmutableDictionary<string, ReportDiagnostic> GetNullableWarningsFromCompiler()
     {
         string[] args = ["/warnaserror:nullable"];
-        var commandLineArguments = CSharpCommandLineParser.Default.Parse(args, baseDirectory: Environment.CurrentDirectory, sdkDirectory: Environment.CurrentDirectory);
-        var nullableWarnings = commandLineArguments.CompilationOptions.SpecificDiagnosticOptions;
+        CSharpCommandLineArguments commandLineArguments = CSharpCommandLineParser.Default.Parse(args, baseDirectory: Environment.CurrentDirectory, sdkDirectory: Environment.CurrentDirectory);
+        ImmutableDictionary<string, ReportDiagnostic> nullableWarnings = commandLineArguments.CompilationOptions.SpecificDiagnosticOptions;
 
         // Workaround for https://github.com/dotnet/roslyn/issues/41610
         nullableWarnings = nullableWarnings

--- a/DocGpt.Test/Verifiers/CSharpVerifierHelper.cs
+++ b/DocGpt.Test/Verifiers/CSharpVerifierHelper.cs
@@ -1,34 +1,33 @@
-﻿namespace DocGpt.Test
+﻿namespace DocGpt.Test;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+using System;
+using System.Collections.Immutable;
+
+internal static class CSharpVerifierHelper
 {
-    using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.CSharp;
+    /// <summary>
+    /// By default, the compiler reports diagnostics for nullable reference types at
+    /// <see cref="DiagnosticSeverity.Warning"/>, and the analyzer test framework defaults to only validating
+    /// diagnostics at <see cref="DiagnosticSeverity.Error"/>. This map contains all compiler diagnostic IDs
+    /// related to nullability mapped to <see cref="ReportDiagnostic.Error"/>, which is then used to enable all
+    /// of these warnings for default validation during analyzer and code fix tests.
+    /// </summary>
+    internal static ImmutableDictionary<string, ReportDiagnostic> NullableWarnings { get; } = GetNullableWarningsFromCompiler();
 
-    using System;
-    using System.Collections.Immutable;
-
-    internal static class CSharpVerifierHelper
+    private static ImmutableDictionary<string, ReportDiagnostic> GetNullableWarningsFromCompiler()
     {
-        /// <summary>
-        /// By default, the compiler reports diagnostics for nullable reference types at
-        /// <see cref="DiagnosticSeverity.Warning"/>, and the analyzer test framework defaults to only validating
-        /// diagnostics at <see cref="DiagnosticSeverity.Error"/>. This map contains all compiler diagnostic IDs
-        /// related to nullability mapped to <see cref="ReportDiagnostic.Error"/>, which is then used to enable all
-        /// of these warnings for default validation during analyzer and code fix tests.
-        /// </summary>
-        internal static ImmutableDictionary<string, ReportDiagnostic> NullableWarnings { get; } = GetNullableWarningsFromCompiler();
+        string[] args = ["/warnaserror:nullable"];
+        var commandLineArguments = CSharpCommandLineParser.Default.Parse(args, baseDirectory: Environment.CurrentDirectory, sdkDirectory: Environment.CurrentDirectory);
+        var nullableWarnings = commandLineArguments.CompilationOptions.SpecificDiagnosticOptions;
 
-        private static ImmutableDictionary<string, ReportDiagnostic> GetNullableWarningsFromCompiler()
-        {
-            string[] args = ["/warnaserror:nullable"];
-            var commandLineArguments = CSharpCommandLineParser.Default.Parse(args, baseDirectory: Environment.CurrentDirectory, sdkDirectory: Environment.CurrentDirectory);
-            var nullableWarnings = commandLineArguments.CompilationOptions.SpecificDiagnosticOptions;
+        // Workaround for https://github.com/dotnet/roslyn/issues/41610
+        nullableWarnings = nullableWarnings
+            .SetItem("CS8632", ReportDiagnostic.Error)
+            .SetItem("CS8669", ReportDiagnostic.Error);
 
-            // Workaround for https://github.com/dotnet/roslyn/issues/41610
-            nullableWarnings = nullableWarnings
-                .SetItem("CS8632", ReportDiagnostic.Error)
-                .SetItem("CS8669", ReportDiagnostic.Error);
-
-            return nullableWarnings;
-        }
+        return nullableWarnings;
     }
 }

--- a/DocGpt.Vsix/DocGpt.Vsix.csproj
+++ b/DocGpt.Vsix/DocGpt.Vsix.csproj
@@ -92,17 +92,17 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI">
-      <Version>1.0.0-beta.12</Version>
+      <Version>1.0.0-beta.17</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0">
-      <Version>17.8.37221</Version>
+      <Version>17.10.40170</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.8.2365">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.10.2179">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.Vsixsigntool">
-      <Version>16.2.29116.78</Version>
+      <Version>17.10.34916.79</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/DocGpt.Vsix/DocGptOptionsPage.cs
+++ b/DocGpt.Vsix/DocGptOptionsPage.cs
@@ -1,12 +1,12 @@
 ﻿namespace DocGpt.Vsix
 {
-    using DocGpt.Options;
-
-    using Microsoft.VisualStudio.Shell;
-
     using System;
     using System.ComponentModel;
     using System.Runtime.InteropServices;
+
+    using DocGpt.Options;
+
+    using Microsoft.VisualStudio.Shell;
 
     /// <summary>
     /// The doc gpt options page.
@@ -25,7 +25,7 @@
         [Category("OpenAI Configuration")]
         [DisplayName("Endpoint URL")]
         [Description("The OpenAI or Azure OpenAI endpoint url.")]
-        public string Endpoint { get => _options.Endpoint?.OriginalString; set => _options.Endpoint = Uri.TryCreate(value, UriKind.Absolute, out var r) ? r : null; }
+        public string Endpoint { get => _options.Endpoint?.OriginalString; set => _options.Endpoint = Uri.TryCreate(value, UriKind.Absolute, out Uri r) ? r : null; }
 
         /// <summary>
         /// Gets or Sets the api key.

--- a/DocGpt.Vsix/DocGptPackage.cs
+++ b/DocGpt.Vsix/DocGptPackage.cs
@@ -1,11 +1,11 @@
 ﻿namespace DocGpt.Vsix
 {
-    using Microsoft.VisualStudio.Shell;
-    using Microsoft.VisualStudio.Shell.Interop;
-
     using System;
     using System.Runtime.InteropServices;
     using System.Threading;
+
+    using Microsoft.VisualStudio.Shell;
+    using Microsoft.VisualStudio.Shell.Interop;
 
     using Task = System.Threading.Tasks.Task;
 
@@ -64,7 +64,7 @@
             // Do any initialization that requires the UI thread after switching to the UI thread.
             await this.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
-            this.GetDialogPage(typeof(DocGptOptionsPage));
+            GetDialogPage(typeof(DocGptOptionsPage));
         }
 
         #endregion


### PR DESCRIPTION
This adds an additional step after getting the GPT response with the following logic:

```mermaid
---
Line Ending Normalization Flow
---
flowchart TD
Lf["`Original Node had 1+
lines ending in \n`"] -- Yes --> CrLf2["`Original Node had 1+
 \r\n lines`"] -- No --> R1["`Replace \r\n with \n`"]
CrLf2 -- Yes --> DN1[Do Nothing]
Lf -- No --> CrLf["`Original Node had 1+
 \r\n lines`"] -- Yes --> R2["`Replace \n with \r\n`"]
CrLf -- No --> DN1
```

Fixes #2 - @adontz could I get your 👀? Thanks!

I took the opportunity to bump nupkgs and do some other housekeeping, but the fix can be found [here](https://github.com/bc3tech/docgpt/pull/3/files#diff-4ca6cc71fdbd909e844c5d68a57affa0e0d20aad44b386ade015de9962354eedR111) with the associated test [here](https://github.com/bc3tech/docgpt/pull/3/files#diff-d4a580a0e510138036f258f4a20a4943701a844b02466249c95d4c84cfa1de21R268).